### PR TITLE
fix: annotations offset and update doc

### DIFF
--- a/docs/en/instance-api.md
+++ b/docs/en/instance-api.md
@@ -288,14 +288,14 @@ Example:
 chart.createAnnotation({
   point: { timestamp: 1614171282000, value: 18987 },
   styles: {
+    offset: [0, 20]
+    position: 'top',
     symbol: {
       type: 'diamond',
-      position: 'top',
       size: 8,
       color: '#2196F3',
       activeSize: 10,
       activeColor: '#FF9600',
-      offset: [0, 20]
     }
   },
   checkPointInCustomSymbol: function ({ point, coordinate, size }) {

--- a/docs/zh-CN/instance-api.md
+++ b/docs/zh-CN/instance-api.md
@@ -289,14 +289,14 @@ chart.createShape({
 chart.createAnnotation({
   point: { timestamp: 1614171282000, value: 18987 },
   styles: {
+    offset: [0, 20]
+    position: 'top',
     symbol: {
       type: 'diamond',
-      position: 'top',
       size: 8,
       color: '#1e88e5',
       activeSize: 10,
       activeColor: '#FF9600',
-      offset: [0, 20]
     }
   },
   checkPointInCustomSymbol: function ({ point, coordinate, size }) {

--- a/src/component/overlay/Annotation.js
+++ b/src/component/overlay/Annotation.js
@@ -200,8 +200,7 @@ export default class Annotation extends Overlay {
    */
   createSymbolCoordinate (x) {
     const styles = this._styles || this._chartData.styleOptions().annotation
-    const symbolOptions = styles.symbol
-    const offset = symbolOptions.offset || [0, 0]
+    const offset = styles.offset || [0, 0]
     this._symbolCoordinate = { x: x + offset[1] }
   }
 


### PR DESCRIPTION
In the documentation it is indicated that you have to use `styles.symbol.position` and `styles.symbol.offset` for the annotations. However, this did not work, it is necessary that these properties are in `styles`, as for the Tags. 
( To be more precise, the `styles.symbol.offset` property was used only for the X axis, and `styles.offset` for the Y axis. )
So I fixed it and updated documentation. 