### PR TITLE
fix: checkEventCoordinateOnCustomSymbol docs example

### DIFF
--- a/docs/en/instance-api.md
+++ b/docs/en/instance-api.md
@@ -298,8 +298,8 @@ chart.createAnnotation({
       activeColor: '#FF9600',
     }
   },
-  checkPointInCustomSymbol: function ({ point, coordinate, size }) {
-    console.log(point, coordinate, size)
+  checkEventCoordinateOnCustomSymbol: function ({ eventCoordinate, coordinate, size }) {
+    console.log(eventCoordinate, coordinate, size)
     return true
   },
   drawCustomSymbol: function ({ ctx, point, coordinate, viewport, isActive, styles }) {

--- a/docs/zh-CN/instance-api.md
+++ b/docs/zh-CN/instance-api.md
@@ -299,8 +299,8 @@ chart.createAnnotation({
       activeColor: '#FF9600',
     }
   },
-  checkPointInCustomSymbol: function ({ point, coordinate, size }) {
-    console.log(point, coordinate, size)
+  checkEventCoordinateOnCustomSymbol: function ({ eventCoordinate, coordinate, size }) {
+    console.log(eventCoordinate, coordinate, size)
     return true
   },
   drawCustomSymbol: function ({ ctx, point, coordinate, viewport, isActive, styles }) {


### PR DESCRIPTION
Wrong docs example for checkEventCoordinateOnCustomSymbol 