### PR TITLE
fix(i18n): add missing 'm' suffix for minute period

### DIFF
--- a/src/extension/i18n/en-US.ts
+++ b/src/extension/i18n/en-US.ts
@@ -24,7 +24,7 @@ const enUS: Locales = {
   turnover: 'Turnover: ',
   change: 'Change: ',
   second: 'S',
-  minute: '',
+  minute: 'm',
   hour: 'H',
   day: 'D',
   week: 'W',

--- a/src/extension/i18n/zh-CN.ts
+++ b/src/extension/i18n/zh-CN.ts
@@ -24,7 +24,7 @@ const zhCN: Locales = {
   turnover: '成交额：',
   change: '涨幅：',
   second: '秒',
-  minute: '',
+  minute: '分',
   hour: '小时',
   day: '天',
   week: '周',


### PR DESCRIPTION
## Summary

The `minute` locale was set to empty string `''` in both en-US and zh-CN, causing period display like "1", "5", "15" instead of "1m", "5m", "15m".

Changes:
- en-US: `minute: ''` -> `minute: 'm'`
- zh-CN: `minute: ''` -> `minute: '分'`

## Before
Period display for minutes: `1`, `5`, `15`, `30`

## After
Period display for minutes: `1m`, `5m`, `15m`, `30m` (en-US) or `1分`, `5分`, `15分`, `30分` (zh-CN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)