### PR TITLE
feat(overlay): add rect, circle, and arrow shape overlays

### DIFF
--- a/src/extension/overlay/arrow.ts
+++ b/src/extension/overlay/arrow.ts
@@ -1,0 +1,61 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OverlayTemplate } from '../../component/Overlay'
+
+const arrow: OverlayTemplate = {
+  name: 'arrow',
+  totalStep: 3,
+  needDefaultPointFigure: true,
+  needDefaultXAxisFigure: true,
+  needDefaultYAxisFigure: true,
+  createPointFigures: ({ coordinates }) => {
+    if (coordinates.length === 2) {
+      const start = coordinates[0]
+      const end = coordinates[1]
+
+      // Calculate arrow head
+      const angle = Math.atan2(end.y - start.y, end.x - start.x)
+      const headLength = 15
+      const headAngle = Math.PI / 6 // 30 degrees
+
+      const arrowHead1 = {
+        x: end.x - headLength * Math.cos(angle - headAngle),
+        y: end.y - headLength * Math.sin(angle - headAngle)
+      }
+      const arrowHead2 = {
+        x: end.x - headLength * Math.cos(angle + headAngle),
+        y: end.y - headLength * Math.sin(angle + headAngle)
+      }
+
+      return [
+        {
+          type: 'line',
+          attrs: { coordinates: [start, end] }
+        },
+        {
+          type: 'line',
+          attrs: { coordinates: [arrowHead1, end] }
+        },
+        {
+          type: 'line',
+          attrs: { coordinates: [arrowHead2, end] }
+        }
+      ]
+    }
+    return []
+  }
+}
+
+export default arrow

--- a/src/extension/overlay/circle.ts
+++ b/src/extension/overlay/circle.ts
@@ -1,0 +1,42 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OverlayTemplate } from '../../component/Overlay'
+
+const circle: OverlayTemplate = {
+  name: 'circle',
+  totalStep: 3,
+  needDefaultPointFigure: true,
+  needDefaultXAxisFigure: true,
+  needDefaultYAxisFigure: true,
+  createPointFigures: ({ coordinates }) => {
+    if (coordinates.length === 2) {
+      const cx = coordinates[0].x
+      const cy = coordinates[0].y
+      const dx = coordinates[1].x - cx
+      const dy = coordinates[1].y - cy
+      const r = Math.sqrt(dx * dx + dy * dy)
+      return [
+        {
+          type: 'circle',
+          attrs: { cx, cy, r },
+          styles: { style: 'stroke' }
+        }
+      ]
+    }
+    return []
+  }
+}
+
+export default circle

--- a/src/extension/overlay/index.ts
+++ b/src/extension/overlay/index.ts
@@ -33,13 +33,18 @@ import verticalStraightLine from './verticalStraightLine'
 import simpleAnnotation from './simpleAnnotation'
 import simpleTag from './simpleTag'
 
+import rect from './rect'
+import circle from './circle'
+import arrow from './arrow'
+
 const overlays: Record<string, OverlayInnerConstructor> = {}
 
 const extensions = [
   fibonacciLine, horizontalRayLine, horizontalSegment, horizontalStraightLine,
   parallelStraightLine, priceChannelLine, priceLine, rayLine, segment,
   straightLine, verticalRayLine, verticalSegment, verticalStraightLine,
-  simpleAnnotation, simpleTag
+  simpleAnnotation, simpleTag,
+  rect, circle, arrow
 ]
 
 extensions.forEach((template: OverlayTemplate) => {

--- a/src/extension/overlay/rect.ts
+++ b/src/extension/overlay/rect.ts
@@ -1,0 +1,41 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OverlayTemplate } from '../../component/Overlay'
+
+const rect: OverlayTemplate = {
+  name: 'rect',
+  totalStep: 3,
+  needDefaultPointFigure: true,
+  needDefaultXAxisFigure: true,
+  needDefaultYAxisFigure: true,
+  createPointFigures: ({ coordinates }) => {
+    if (coordinates.length === 2) {
+      const x = Math.min(coordinates[0].x, coordinates[1].x)
+      const y = Math.min(coordinates[0].y, coordinates[1].y)
+      const width = Math.abs(coordinates[1].x - coordinates[0].x)
+      const height = Math.abs(coordinates[1].y - coordinates[0].y)
+      return [
+        {
+          type: 'rect',
+          attrs: { x, y, width, height },
+          styles: { style: 'stroke' }
+        }
+      ]
+    }
+    return []
+  }
+}
+
+export default rect


### PR DESCRIPTION
## Summary
Add three new shape overlays for drawing on charts:
- `rect`: Rectangle overlay defined by two corner points
- `circle`: Circle overlay defined by center and edge point  
- `arrow`: Arrow overlay with line and arrowhead at end point

## Changes
- `src/extension/overlay/rect.ts`: Rectangle shape overlay
- `src/extension/overlay/circle.ts`: Circle shape overlay
- `src/extension/overlay/arrow.ts`: Arrow shape overlay
- `src/extension/overlay/index.ts`: Register new overlays

## Test plan
- [ ] Draw rectangles on the chart
- [ ] Draw circles on the chart
- [ ] Draw arrows on the chart
- [ ] Verify shapes persist across timeframe changes