### PR TITLE
fix: exclude _prevIndicator from override snapshot to prevent memory leak

### DIFF
--- a/src/component/Indicator.ts
+++ b/src/component/Indicator.ts
@@ -380,7 +380,7 @@ export default class IndicatorImp<D = unknown, C = unknown, E = unknown> impleme
   }
 
   override (indicator: Partial<Indicator<D, C, E>>): void {
-    const { result, ...currentOthers } = this
+    const { result, _prevIndicator, ...currentOthers } = this
     this._prevIndicator = { ...clone(currentOthers), result }
     const {
       id,


### PR DESCRIPTION
Same class of bug as #710 (which fixed `_prevOverlay`), but for `Indicator`.

`override` snapshots `_prevIndicator` via `clone(currentOthers)`, and `currentOthers` still contains the previous `_prevIndicator`. So each call deep-clones the prior snapshot chain, pinning every superseded `result` array — an unbounded leak for consumers that override on each tick or resize.

Excluding `_prevIndicator` from the clone fixes it. Only one level of history is ever read (`shouldUpdate` / `shouldUpdateImp`), so nothing else changes.

Refs #691. Verified: `code-lint`, `type-check`, `build-esm` all pass.
