### PR TITLE
fix: y-axis widget loses height after axis type override + indicator removal

### DIFF
--- a/src/pane/DrawPane.ts
+++ b/src/pane/DrawPane.ts
@@ -103,6 +103,12 @@ export default abstract class DrawPane<C extends Axis = Axis> extends Pane {
         const yAxisWidget = this.createYAxisWidget(this.getContainer(), yAxis)
         if (isValid(yAxisWidget)) {
           this._yAxisWidgets.set(yAxisId, yAxisWidget)
+          // Inherit the pane's current geometry. Recreating the axis (e.g. via
+          // `overrideYAxis({ name })`) destroys the old widget, and follow-up
+          // layouts only measure width, so without this the new widget keeps
+          // height 0 and the axis collapses (squashed bars, no ticks).
+          const bounding = this.getBounding()
+          yAxisWidget.setBounding({ height: bounding.height, top: bounding.top })
         }
       }
     }


### PR DESCRIPTION
## Problem

Recreating a y-axis (e.g. `overrideYAxis({ name: 'percentage' })` to switch axis
type) destroys the old axis widget and creates a fresh one with zero bounding.
The layout triggered by `overrideYAxis` only measures width, so the new widget
keeps `height: 0` until an unrelated `measureHeight` layout (such as a container
resize) happens to run. While in that state, value-to-pixel conversion collapses:
candles are squashed into a single line at the pane edge and axis ticks disappear.

## Reproduction

1. `createIndicator(ind, { isStack: true, pane: { id: 'candle_pane' }, yAxis: { id: 'my_axis', position: 'left' } })`
2. `overrideYAxis({ paneId: 'candle_pane', name: 'percentage' })`
3. `overrideYAxis({ paneId: 'candle_pane', name: 'normal' })`
4. `removeIndicator({ paneId: 'candle_pane', name: ... })`

→ candle pane collapses (`getSize('candle_pane', 'yAxis').height === 0`).

Verified on 10.0.0-beta3 and current main.

## Fix

When `DrawPane.createYAxis` creates a new axis widget, inherit the pane's current
`height`/`top` so the widget stays consistent with pane geometry. Width is still
handled by the subsequent measure-width layout, unchanged.

After the fix the same sequence keeps the axis widget at the pane height and the
chart renders correctly (also verified with percentage → logarithm → normal
switches before removal). `pnpm type-check` passes.
