### PR TITLE
fix: PVT divided by volume instead of multiplying

### DIFF
--- a/src/extension/indicator/priceAndVolumeTrend.ts
+++ b/src/extension/indicator/priceAndVolumeTrend.ts
@@ -37,9 +37,8 @@ const priceAndVolumeTrend: IndicatorTemplate<Pvt> = {
       const volume = kLineData.volume ?? 1
       const prevClose = (dataList[i - 1] ?? kLineData).close
       let x = 0
-      const total = prevClose * volume
-      if (total !== 0) {
-        x = (close - prevClose) / total
+      if (prevClose !== 0) {
+        x = ((close - prevClose) / prevClose) * volume
       }
       sum += x
       pvt.pvt = sum


### PR DESCRIPTION
Fixes #811

The comment above the code says multiply by volume but the code divided instead, so PVT flattens to near zero at normal volume sizes.

src/extension/indicator/priceAndVolumeTrend.ts:
- const total = prevClose * volume
- if (total !== 0) {
-   x = (close - prevClose) / total
+ if (prevClose !== 0) {
+   x = ((close - prevClose) / prevClose) * volume
