### PR TITLE
fix: correct CR indicator MID formula to match canonical definition

### DIFF
--- a/src/extension/indicator/currentRatio.ts
+++ b/src/extension/indicator/currentRatio.ts
@@ -67,7 +67,7 @@ const currentRatio: IndicatorTemplate<Cr, number> = {
     dataList.forEach((kLineData, i) => {
       const cr: Cr = {}
       const prevData = dataList[i - 1] ?? kLineData
-      const prevMid = (prevData.high + prevData.close + prevData.low + prevData.open) / 4
+      const prevMid = (prevData.high + prevData.low) / 2
 
       const highSubPreMid = Math.max(0, kLineData.high - prevMid)
 


### PR DESCRIPTION
## Problem

The CR (energy ratio) indicator computes its reference mid-price `MID` with a non-standard formula:

```js
// src/extension/indicator/currentRatio.ts:70
const prevMid = (prevData.high + prevData.close + prevData.low + prevData.open) / 4
```

This is `(O + H + L + C) / 4` of the previous bar. No standard CR implementation includes the **open** price in `MID`, and it contradicts the file's own doc comment right above the code:

```
MID:=REF(HIGH+LOW,1)/2;
...
MID赋值:(昨日最高价+昨日最低价)/2
```

i.e. `MID = (previous_high + previous_low) / 2`. As a result, every CR value (and its four MA bands) differs from every other platform (TradingView / moomoo / 通达信 TDX).

`git blame` shows the line was carried over during the 2022 JS→TS refactor (`af5e38fbb7 refactor: ts refactor`) and the surrounding math dates back to 2020 — it was not a deliberate choice of formula.

## Fix

Use the canonical mid-price, matching the documented formula:

```diff
-      const prevMid = (prevData.high + prevData.close + prevData.low + prevData.open) / 4
+      const prevMid = (prevData.high + prevData.low) / 2
```

## Verification

- `pnpm type-check` — pass (exit 0)
- `pnpm build-esm` (runs `code-lint` via biome, then ESM build) — pass (154 files checked, no fixes, exit 0)

## Notes

- This **changes the numeric output** of the CR indicator. Users relying on the previous (non-standard) values will see different numbers after this change — values now match the canonical TDX definition (`MID = REF(HIGH+LOW,1)/2`).
- No public API, figures, or parameter changes.
- `calcParams`, the four MA bands, and the division guard (`preMidSubLow !== 0`) are untouched.

## References

- [Futu / moomoo — CR energy index](https://www.futuhk.com/hans/support/topic1_167)
- [通达信 CR formula (gupang.com)](https://www.gupang.com/201404/0425331R2014.html) — `MID:=REF(HIGH+LOW,1)/2`
- [MBA Lib — CR indicator](https://wiki.mbalib.com/zh-tw/CR%E6%8C%87%E6%A8%99)