### PR TITLE
fix: correct ROC indicator lookback window and MA threshold

### DIFF
--- a/src/extension/indicator/rateOfChange.ts
+++ b/src/extension/indicator/rateOfChange.ts
@@ -37,16 +37,16 @@ const rateOfChange: IndicatorTemplate<Roc, number> = {
     let rocSum = 0
     dataList.forEach((kLineData, i) => {
       const roc: Roc = {}
-      if (i >= params[0] - 1) {
+      if (i >= params[0]) {
         const close = kLineData.close
-        const agoClose = (dataList[i - params[0]] ?? dataList[i - (params[0] - 1)]).close
+        const agoClose = dataList[i - params[0]].close
         if (agoClose !== 0) {
           roc.roc = ((close - agoClose) / agoClose) * 100
         } else {
           roc.roc = 0
         }
         rocSum += roc.roc
-        if (i >= params[0] - 1 + params[1] - 1) {
+        if (i >= params[0] + params[1] - 1) {
           roc.maRoc = rocSum / params[1]
           rocSum -= result[i - (params[1] - 1)].roc ?? 0
         }


### PR DESCRIPTION
## Problem

The ROC (Rate of Change) indicator has an off-by-one in its lookback window:

```js
// src/extension/indicator/rateOfChange.ts
if (i >= params[0] - 1) {                                                       // i >= 11 for N=12
  const agoClose = (dataList[i - params[0]] ?? dataList[i - (params[0] - 1)]).close
  ...
  if (i >= params[0] - 1 + params[1] - 1) {                                     // MA window threshold
```

For `calcParams: [12, 6]` (N=12), ROC is computed starting at `i = 11`, but the
lookback `dataList[i - params[0]]` = `dataList[-1]` is `undefined`. The fallback
`dataList[i - (params[0] - 1)]` = `dataList[0]` then kicks in, so the first
computed point is an **11-period** ROC instead of a 12-period one.

The canonical definition (and the sibling `momentum.ts`, which uses the same
`calcParams` and a correct sliding window) computes the value only once a full
`N`-bar history exists:

```js
// momentum.ts (correct reference)
if (i >= params[0]) {
  const agoClose = dataList[i - params[0]].close
  ...
  if (i >= params[0] + params[1] - 1) {
```

`git blame` shows the thresholds (`i >= params[0] - 1` and the MA window) date
back to the 2021 JS implementation (`2aab3b64c5`), and the `??` fallback was
added during the 2022 JS→TS refactor (`af5e38fbb7`) — masking the off-by-one
rather than fixing it.

## Fix

Align the window with the canonical definition and with `momentum.ts`:

```diff
-      if (i >= params[0] - 1) {
+      if (i >= params[0]) {
         const close = kLineData.close
-        const agoClose = (dataList[i - params[0]] ?? dataList[i - (params[0] - 1)]).close
+        const agoClose = dataList[i - params[0]].close
         if (agoClose !== 0) {
           roc.roc = ((close - agoClose) / agoClose) * 100
         } else {
           roc.roc = 0
         }
         rocSum += roc.roc
-        if (i >= params[0] - 1 + params[1] - 1) {
+        if (i >= params[0] + params[1] - 1) {
           roc.maRoc = rocSum / params[1]
           rocSum -= result[i - (params[1] - 1)].roc ?? 0
         }
```

The MA threshold is updated together with the ROC threshold because the two are
coupled in the sliding window: keeping the old MA threshold while shifting the
ROC start would make `maRoc` average 5 values instead of 6 at its first point.

## Verification

- `pnpm type-check` — pass (exit 0)
- `pnpm build-esm` (runs `code-lint` via biome, then ESM build) — pass (154 files checked, no fixes, exit 0)

## Notes

- The first `N - 1` bars (where a full N-period change is not yet available)
  now correctly produce `undefined` instead of a shortened-window value, matching
  the behaviour of `momentum.ts` / `MA` / `EMA` / etc.
- No public API, figure, or parameter changes. `calcParams`, the division guard
  (`agoClose !== 0`), and the `* 100` scaling are untouched.