### PR TITLE
fix: reset SAR acceleration factor to startAf on down-to-up reversal

### DIFF
--- a/src/extension/indicator/stopAndReverse.ts
+++ b/src/extension/indicator/stopAndReverse.ts
@@ -90,7 +90,7 @@ const stopAndReverse: IndicatorTemplate<Sar, number> = {
         if (sar < kLineData.high) {
           sar = ep
           // 重新初始化值
-          af = 0
+          af = startAf
           ep = -100
           isIncreasing = !isIncreasing
         } else if (sar < highMax) {


### PR DESCRIPTION
## Problem

The Parabolic SAR indicator resets its Acceleration Factor (AF) asymmetrically
on the two reversal types:

```js
// src/extension/indicator/stopAndReverse.ts
// up → down reversal (line 73-78)
if (sar > kLineData.low) {
  sar = ep
  // 重新初始化值
  af = startAf          // ✅ reset to initial value (0.02)
  ep = -100
  isIncreasing = !isIncreasing
}

// down → up reversal (line 90-95)
if (sar < kLineData.high) {
  sar = ep
  // 重新初始化值
  af = 0                // ❌ reset to 0
  ep = -100
  isIncreasing = !isIncreasing
}
```

With `calcParams: [2, 2, 20]` → `startAf = 0.02`, `step = 0.02`, `maxAf = 0.20`,
the two branches are meant to be symmetric (both reset AF on reversal). But the
down→up branch resets `af = 0` instead of `af = startAf`.

On the bar following the reversal, the `ep === -100` guard unconditionally
increments AF:
- after **up→down**: `af = min(0.02 + 0.02, 0.20) = 0.04`
- after **down→up**: `af = min(0 + 0.02, 0.20) = 0.02`

So a downtrend accelerates faster than an uptrend after the equivalent reversal.
The canonical Parabolic SAR (Wilder) resets AF to its initial value on **both**
reversal types; `af = 0` appears in no standard implementation.

`git blame` shows both branches were written in the same commit (`cdf340ba73`,
2020-05-17), with identical `// 重新初始化值` ("re-initialize value") comments.
The down→up branch is a copy of the up→down branch where the value was not
updated — the same class of parallel-branch divergence as the colour-channel
swap fixed in #807.

## Fix

Reset AF to the initial value on both reversal types:

```diff
         if (sar < kLineData.high) {
           sar = ep
           // 重新初始化值
-          af = 0
+          af = startAf
           ep = -100
           isIncreasing = !isIncreasing
```

## Verification

- `pnpm type-check` — pass (exit 0)
- `pnpm build-esm` (runs `code-lint` via biome, then ESM build) — pass (154 files checked, no fixes, exit 0)

## Notes

- Only the AF reset value on the down→up reversal is changed; the symmetric
  `ep = -100` reset and the unconditional AF increment on the next bar are left
  untouched, so the change is minimal and the reversal logic stays symmetric.
- No public API, figure, or parameter changes.