### PR TITLE
fix: use yAxis tick text size for y-axis tick collision filter

### DIFF
--- a/src/component/YAxis.ts
+++ b/src/component/YAxis.ts
@@ -314,7 +314,7 @@ export default abstract class YAxisImp extends AxisImp implements YAxis {
     const formatter = chartStore.getInnerFormatter()
     const thousandsSeparator = chartStore.getThousandsSeparator()
     const decimalFold = chartStore.getDecimalFold()
-    const textHeight = styles.xAxis.tickText.size
+    const textHeight = styles.yAxis.tickText.size
     let validY = NaN
     ticks.forEach(({ value }) => {
       let v = this.displayValueToText(+value, precision)


### PR DESCRIPTION
## Problem

In `YAxisImp.createTicksImp`, the tick-collision filter and the top/bottom margin
clamp read the tick-text size from the **x-axis** styles instead of the **y-axis**:

```js
// src/component/YAxis.ts:317
const textHeight = styles.xAxis.tickText.size
...
// line 327 — textHeight drives the collision filter and the top/bottom padding
if (y > textHeight && y < height - textHeight &&
    ((validYNumber && Math.abs(validY - y) > textHeight * 2) || !validYNumber)) {
```

The other two tick-text references in the same file read the correct source:
- `src/component/YAxis.ts:347` → `const yAxisStyles = styles.yAxis`
- `src/component/YAxis.ts:363` → `yAxisStyles.tickText.size`

So within `YAxis.ts`, two references use the y-axis styles and one uses the
x-axis styles. `XAxis.ts` consistently references only `styles.xAxis`. The
mismatch is one-sided, which rules out an intentional shared value.

The default `tickText.size` is `12` for both axes (`src/common/Styles.ts:659`),
so the bug is invisible out of the box. It surfaces as soon as the y-axis text
is styled independently of the x-axis — a documented public config path:

```js
chart.setStyles({ yAxis: { tickText: { size: 18 } } }) // x-axis stays at 12
```

The collision filter keeps using `12`, so y-axis labels crowd/overlap and the
top/bottom padding is wrong relative to the actual label height.

## Fix

Read the tick-text size from the y-axis styles:

```diff
-    const textHeight = styles.xAxis.tickText.size
+    const textHeight = styles.yAxis.tickText.size
```

After the change, no `xAxis` references remain in `YAxis.ts`.

## Verification

- `pnpm type-check` — pass (exit 0)
- `pnpm build-esm` (runs `code-lint` via biome, then ESM build) — pass (154 files checked, no fixes, exit 0)

## Notes

- Default styling is unaffected (both axes default to size `12`), so this only
  changes behaviour when the y-axis tick text is customised independently.
- No public API or style-shape changes.