### PR TITLE
fix: guard overlay timestamp assignment against undefined in pressed move

### DIFF
--- a/src/component/Overlay.ts
+++ b/src/component/Overlay.ts
@@ -410,7 +410,9 @@ export default class OverlayImp<E = unknown> implements Overlay<E> {
   }
 
   eventPressedPointMove(point: Partial<Point>, pointIndex: number): void {
-    this.points[pointIndex].timestamp = point.timestamp
+    if (isNumber(point.timestamp)) {
+      this.points[pointIndex].timestamp = point.timestamp
+    }
     if (isNumber(point.dataIndex)) {
       this.points[pointIndex].dataIndex = point.dataIndex
     }


### PR DESCRIPTION
## Problem

`OverlayImp.eventPressedPointMove` assigns `point.timestamp` unconditionally,
while the sibling fields (`dataIndex`, `value`) are guarded with `isNumber`:

```js
// src/component/Overlay.ts
eventPressedPointMove(point: Partial<Point>, pointIndex: number): void {
  this.points[pointIndex].timestamp = point.timestamp   // ❌ no guard
  if (isNumber(point.dataIndex)) {                      // ✓ guarded
    this.points[pointIndex].dataIndex = point.dataIndex
  }
  if (isNumber(point.value)) {                          // ✓ guarded
    this.points[pointIndex].value = point.value
  }
  ...
}
```

`point` is built by `OverlayView._coordinateToPoint`, which sets
`timestamp = chartStore.dataIndexToTimestamp(dataIndex) ?? undefined`.
`dataIndexToTimestamp` returns `null` when `dataList` is empty or the lookup
fails and no period is configured (`src/Store.ts:950`). In that case
`point.timestamp` is `undefined`, and this line overwrites a previously valid
timestamp on the dragged point — dropping the point from its time-based
placement for overlays placed by `{ timestamp, value }`.

## Fix

Guard the assignment the same way the sibling fields (and the other move
handlers in this file) are guarded:

```diff
   eventPressedPointMove(point: Partial<Point>, pointIndex: number): void {
-    this.points[pointIndex].timestamp = point.timestamp
+    if (isNumber(point.timestamp)) {
+      this.points[pointIndex].timestamp = point.timestamp
+    }
     if (isNumber(point.dataIndex)) {
```

The same `if (isNumber(point.timestamp))` guard is already used by the two
neighbouring move handlers in this file (`continuousDrawingModeEventMoveForDrawing`
and `stepDrawingModeEventMoveForDrawing`), so this brings `eventPressedPointMove`
in line with them.

## Verification

- `pnpm type-check` — pass (exit 0)
- `pnpm build-esm` (runs `code-lint` via biome, then ESM build) — pass (154 files checked, no fixes, exit 0)

## Notes

- Only the timestamp assignment is guarded; `dataIndex`/`value` handling and the
  `performEventPressedMove` callback are untouched.
- No public API changes.