### PR TITLE
fix: format negative values and exact magnitude boundaries in formatBigNumber

### DIFF
--- a/src/common/utils/format.ts
+++ b/src/common/utils/format.ts
@@ -102,14 +102,16 @@ export function formatPrecision(value: string | number, precision?: number): str
 export function formatBigNumber(value: string | number): string {
   const v = +value
   if (isNumber(v)) {
-    if (v > 1000000000) {
-      return `${+(v / 1000000000).toFixed(3)}B`
+    const sign = v < 0 ? '-' : ''
+    const a = Math.abs(v)
+    if (a >= 1000000000) {
+      return `${sign}${+(a / 1000000000).toFixed(3)}B`
     }
-    if (v > 1000000) {
-      return `${+(v / 1000000).toFixed(3)}M`
+    if (a >= 1000000) {
+      return `${sign}${+(a / 1000000).toFixed(3)}M`
     }
-    if (v > 1000) {
-      return `${+(v / 1000).toFixed(3)}K`
+    if (a >= 1000) {
+      return `${sign}${+(a / 1000).toFixed(3)}K`
     }
   }
   return `${value}`


### PR DESCRIPTION
## Problem

`formatBigNumber` compares the raw value with `>`, so it skips two cases:

```js
// src/common/utils/format.ts
export function formatBigNumber(value: string | number): string {
  const v = +value
  if (isNumber(v)) {
    if (v > 1000000000) { ... }   // ❌ negative values bypass all branches
    if (v > 1000000) { ... }       // ❌ exact boundary not formatted (1000M instead of 1B)
    if (v > 1000) { ... }
  }
  return `${value}`
}
```

1. **Negatives are never formatted.** `formatBigNumber(-1500000)` returns
   `"-1500000"` while its positive counterpart returns `"1.5M"`, so symmetric
   large values render inconsistently (e.g. axis ticks / last-value labels).
2. **Exact magnitude boundaries fall through.** `formatBigNumber(1000000000)`
   returns `"1000000000"` (well, `"1000M"` via the next branch) instead of `"1B"`
   because of the strict `>`.

## Fix

Compare by magnitude and reattach the sign, and use `>=`:

```diff
 export function formatBigNumber(value: string | number): string {
   const v = +value
   if (isNumber(v)) {
-    if (v > 1000000000) {
-      return `${+(v / 1000000000).toFixed(3)}B`
-    }
-    if (v > 1000000) {
-      return `${+(v / 1000000).toFixed(3)}M`
-    }
-    if (v > 1000) {
-      return `${+(v / 1000).toFixed(3)}K`
-    }
+    const sign = v < 0 ? - : 
+    const a = Math.abs(v)
+    if (a >= 1000000000) {
+      return `${sign}${+(a / 1000000000).toFixed(3)}B`
+    }
+    if (a >= 1000000) {
+      return `${sign}${+(a / 1000000).toFixed(3)}M`
+    }
+    if (a >= 1000) {
+      return `${sign}${+(a / 1000).toFixed(3)}K`
+    }
   }
   return `${value}`
 }
```

Result:

| input | before | after |
|---|---|---|
| `1500000` | `1.5M` | `1.5M` |
| `-1500000` | `-1500000` | `-1.5M` |
| `1000000000` | `1000M` | `1B` |
| `-1000000000` | `-1000000000` | `-1B` |
| `1000000` | `1000K` | `1M` |
| `999` / `0` / `NaN` / `"abc"` | unchanged | unchanged |

## Reachability

`formatBigNumber` is exported through the public `utils` API (`src/index.ts`)
and is applied to indicator values when `shouldFormatBigNumber` is set. The only
built-in indicator setting it is `volume` (non-negative), so negatives are not
reached by built-ins — but the function is a public utility and custom
indicators (e.g. volume-delta / OBV-like) can produce large negatives, where the
asymmetric output is visible.

## Verification

- `pnpm type-check` — pass (exit 0)
- `pnpm build-esm` (runs `code-lint` via biome, then ESM build) — pass (154 files checked, no fixes, exit 0)

## Notes

- Behaviour is unchanged for values already handled correctly (small positives,
  `NaN`, non-numeric strings fall through to `return \`${value}\``).
- No public API signature changes.