### PR TITLE
fix: prevent NaN in percentage y-axis on flat data or zero base price

### DIFF
--- a/src/extension/y-axis/percentage.ts
+++ b/src/extension/y-axis/percentage.ts
@@ -20,16 +20,17 @@ const percentage: AxisTemplate = {
   name: 'percentage',
   minSpan: () => Math.pow(10, -2),
   displayValueToText: (value) => `${formatPrecision(value, 2)}%`,
-  valueToRealValue: (value, { range }) => ((value - range.from) / range.range) * range.realRange + range.realFrom,
-  realValueToValue: (value, { range }) => ((value - range.realFrom) / range.realRange) * range.range + range.from,
+  valueToRealValue: (value, { range }) => (range.range === 0 ? range.realFrom : ((value - range.from) / range.range) * range.realRange + range.realFrom),
+  realValueToValue: (value, { range }) => (range.realRange === 0 ? range.from : ((value - range.realFrom) / range.realRange) * range.range + range.from),
   createRange: ({ chart, defaultRange }) => {
     const kLineDataList = chart.getDataList()
     const visibleRange = chart.getVisibleRange()
     const kLineData = kLineDataList[visibleRange.from]
     if (isValid(kLineData)) {
       const { from, to, range } = defaultRange
-      const realFrom = ((defaultRange.from - kLineData.close) / kLineData.close) * 100
-      const realTo = ((defaultRange.to - kLineData.close) / kLineData.close) * 100
+      const base = kLineData.close
+      const realFrom = base === 0 ? 0 : ((defaultRange.from - base) / base) * 100
+      const realTo = base === 0 ? 0 : ((defaultRange.to - base) / base) * 100
       const realRange = realTo - realFrom
       return {
         from,


### PR DESCRIPTION
## Problem

The percentage y-axis divides without guards in three places, producing
`NaN`/`Infinity` that propagate into coordinates and break the pane:

```js
// src/extension/y-axis/percentage.ts
valueToRealValue: (value, { range }) => ((value - range.from) / range.range) * range.realRange + range.realFrom,
realValueToValue: (value, { range }) => ((value - range.realFrom) / range.realRange) * range.range + range.from,
createRange: ({ chart, defaultRange }) => {
  ...
  const realFrom = ((defaultRange.from - kLineData.close) / kLineData.close) * 100   // close === 0 ?
  const realTo   = ((defaultRange.to   - kLineData.close) / kLineData.close) * 100
  ...
}
```

Two reachable cases:

1. **Flat visible data** (every visible value equal). `defaultRange.range === 0`
   (min === max), so `range.range === 0` is copied into the returned range
   (`createRange` line `range: range`). The next `valueToRealValue` /
   `realValueToValue` calls (e.g. `YAxisImp.createRangeImp` lines 241-244, tick
   building line 321) then divide by zero → `NaN`/`Infinity` pixel coordinates
   → the pane renders blank/broken.
2. **First visible bar close === 0.** `createRange` divides by `kLineData.close`
   → `realFrom`/`realTo` become `±Infinity`, and everything downstream becomes
   `NaN`.

The normal axis is immune: its conversions are the identity, and
`createRangeImp` (lines 190-196) replaces an empty range with `0..10` before
any division. The percentage `createRange` callback receives `range.range`
verbatim from `defaultRange.range`, so that guard does not protect it.

Empirically (replicating the functions):

| input | before | after |
|---|---|---|
| flat data, `valueToRealValue(100)` | `NaN` | `0` |
| flat data, `realValueToValue(0)` | `NaN` | `100` |
| close=0, `valueToRealValue(100)` | `NaN` | `0` |
| close=0, `realValueToValue(0)` | `NaN` | `90` |

## Fix

Guard the three divisions. When a range is degenerate, return the boundary
value that a zero-width range collapses to (so the axis maps everything to a
single point instead of producing `NaN`):

```diff
-  valueToRealValue: (value, { range }) => ((value - range.from) / range.range) * range.realRange + range.realFrom,
-  realValueToValue: (value, { range }) => ((value - range.realFrom) / range.realRange) * range.range + range.from,
+  valueToRealValue: (value, { range }) => (range.range === 0 ? range.realFrom : ((value - range.from) / range.range) * range.realRange + range.realFrom),
+  realValueToValue: (value, { range }) => (range.realRange === 0 ? range.from : ((value - range.realFrom) / range.realRange) * range.range + range.from),
   createRange: ({ chart, defaultRange }) => {
     ...
-      const realFrom = ((defaultRange.from - kLineData.close) / kLineData.close) * 100
-      const realTo = ((defaultRange.to - kLineData.close) / kLineData.close) * 100
+      const base = kLineData.close
+      const realFrom = base === 0 ? 0 : ((defaultRange.from - base) / base) * 100
+      const realTo = base === 0 ? 0 : ((defaultRange.to - base) / base) * 100
```

Only `percentage.ts` is touched — the shared axis contract in `YAxis.ts` is
unchanged, so normal/logarithm axes are unaffected.

## Verification

- `pnpm type-check` — pass (exit 0)
- `pnpm build-esm` (runs `code-lint` via biome, then ESM build) — pass (154 files checked, no fixes, exit 0)
- Conversion functions manually checked on flat-data, zero-base, and a normal
  case (normal case still returns the canonical values, e.g. close=100 →
  `valueToRealValue(110) = 10`, `realValueToValue(10) = 110`).

## Notes

- Behaviour is unchanged for the normal case; only degenerate inputs now yield
  finite values instead of `NaN`/`Infinity`.
- No public API changes.