### PR TITLE
fix: look up existing chart by k-line-chart-id in init to prevent duplicates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ function init(ds: HTMLElement | string, options?: Options): Nullable<Chart> {
     logError('', '', 'The chart cannot be initialized correctly. Please check the parameters. The chart container cannot be null and child elements need to be added!!!')
     return null
   }
-  let chart = charts.get(dom.id)
+  let chart = charts.get(dom.getAttribute('k-line-chart-id') ?? '')
   if (isValid(chart)) {
     logWarn('', '', 'The chart has been initialized on the dom！！！')
     return chart


### PR DESCRIPTION
## Problem

`init` stores charts under a generated id (`k_line_chart_N`) but the
already-initialized check looks them up by `dom.id`, so the two keys never
match:

```js
// src/index.ts
function init(ds, options) {
  ...
  let chart = charts.get(dom.id)                         // ❌ looks up by dom.id
  if (isValid(chart)) { ... return chart }
  const id = `k_line_chart_${chartBaseId++}`             // stored under k_line_chart_N
  chart = new ChartImp(dom, options)
  chart.id = id
  dom.setAttribute(k-line-chart-id, id)                // written to the attribute
  charts.set(id, chart)                                  // stored under k_line_chart_N
  return chart
}
```

`dispose` reads the same `k-line-chart-id` attribute (`dom.getAttribute(...)`),
so `init` and `dispose` disagree with each other on which key identifies a
chart on a given DOM node.

Consequences of calling `init(el)` twice on the same element:

- The duplicate check never matches, so a **second** `ChartImp` is created on
  the same container — two charts appending children, two `ResizeObserver`s,
  double rendering.
- The first chart is still reachable through the `charts` map under its own
  `k_line_chart_N` key, so it is never cleaned up by the second `init` or by a
  later `dispose(el)` (which only destroys the last-created one).

This also affects elements without an `id` (`init(element)`), where `dom.id`
is `""` and the lookup can never succeed regardless.

## Fix

Look up by the same key that `init` writes and `dispose` reads — the
`k-line-chart-id` attribute:

```diff
-  let chart = charts.get(dom.id)
+  let chart = charts.get(dom.getAttribute(k-line-chart-id) ?? )
```

Now `init`, the storage key (`charts.set(id, …)`), and `dispose` all agree on
`k_line_chart_N` as the identifier, so the duplicate guard works and repeated
`init(el)` calls return the existing chart (with the existing
"The chart has been initialized on the dom！！！" warning) instead of creating a
second one.

## Verification

- `pnpm type-check` — pass (exit 0)
- `pnpm build-esm` (runs `code-lint` via biome, then ESM build) — pass (154 files checked, no fixes, exit 0)

## Notes

- No public API signature changes. `init` still accepts an id string or an
  element and still returns the existing chart when one is already attached.
- The generated `k_line_chart_N` storage key and the `k-line-chart-id`
  attribute are unchanged; only the lookup source is corrected.