### PR TITLE
perf: add fast path in formatValue for separator-free keys

### DIFF
--- a/src/common/utils/format.ts
+++ b/src/common/utils/format.ts
@@ -27,6 +27,19 @@ const reEscapeChar = /\\(\\)?/g
 const rePropName = new RegExp('[^.[\\]]+' + '|' + '\\[(?:' + '([^"\'][^[]*)' + '|' + '(["\'])((?:(?!\\2)[^\\\\]|\\\\.)*?)\\2' + ')\\]' + '|' + '(?=(?:\\.|\\[\\])(?:\\.|\\[\\]|$))', 'g')
 
 export function formatValue(data: unknown, key: string, defaultValue?: unknown): unknown {
+  // Fast path: simple single-segment key without path separators.
+  // `rePropName` below splits on '.', '[', and ']', so a key containing any of those
+  // is compound and must take the general path. A separator-free key parses to a
+  // single-element `path` and resolves to `data[key]`, which an inline read matches exactly.
+  // This avoids a regex match + closure + array allocation per call, which matters in hot paths
+  // (e.g. `eachFigures` runs 4 `formatValue` calls per visible bar per indicator).
+  if (key.length > 0 && !key.includes('.') && !key.includes('[') && !key.includes(']')) {
+    if (isValid(data)) {
+      const value = (data as Record<string, unknown>)[key]
+      return isValid(value) ? value : (defaultValue ?? '--')
+    }
+    return defaultValue ?? '--'
+  }
   if (isValid(data)) {
     const path: string[] = []
     key.replace(rePropName, (subString: string, ...args: unknown[]) => {


### PR DESCRIPTION
## Problem

`formatValue(data, key, defaultValue)` resolves a (possibly compound) key from an
object. The general path runs `key.replace(rePropName, …)` — a regex match plus a
closure plus a `path[]` array allocation — on every call.

This matters on the hottest draw path: `Indicator.eachFigures`
(`src/component/Indicator.ts:249-263`) calls `formatValue` **4 times per visible
bar per indicator** on every repaint (pan / zoom / real-time), and with simple
single-segment keys: `'texts'`, `'circles'`, `'bars'`, `'lines'`. At ~300 bars × 3
indicators that is ~3600 regex calls per frame, all on keys that contain no path
separators and resolve trivially to `data[key]`.

## Fix

Add a fast path before the regex path: if the key contains no `.` / `[` / `]`, read
the property directly. Compound keys (`'ohlc.upColor'`, `'circles[0].upColor'`) keep the
existing regex path unchanged.

```ts
if (key.length > 0 && !key.includes('.') && !key.includes('[') && !key.includes(']')) {
  if (isValid(data)) {
    const value = (data as Record<string, unknown>)[key]
    return isValid(value) ? value : (defaultValue ?? '--')
  }
  return defaultValue ?? '--'
}
```

### Why the guard includes `]`

`rePropName` splits a path on `.`, `[`, **and** `]`. A key like `'a]b'` parses as the
compound path `["a","b"]`, so it must take the regex path. A guard that only
checked `.` and `[` would wrongly route `'a]b'` into the fast path as a single key.
No caller in the codebase passes such a key, but `formatValue` is a public
utility, so the guard is closed fully for exact equivalence with the regex path.

## Verification

- Behaviour equivalence: 128 cases (8 data forms × 16 keys, incl. `__proto__`,
  `constructor`, `toString`, `null`/`undefined` data, numeric array keys, empty
  key) — **0 differences** between fast and regex path.
- Empty key (`length === 0`) is excluded from the fast path and falls through to
  the regex path, matching prior behaviour.
- `pnpm code-lint` — pass (154 files, no fixes)
- `pnpm type-check` — pass
- `pnpm build-umd:prod` — pass

## Notes

- No public API change. `isValid` semantics (`!= null && != undefined`) and the
  `defaultValue ?? '--'` fallback are preserved.
- Only `formatValue` is touched; `formatBigNumber`, `formatThousands`,
  `formatPrecision`, etc. are unchanged.