### PR TITLE
perf: cache parsed SVG path commands in path figure

### DIFF
--- a/src/extension/figure/path.ts
+++ b/src/extension/figure/path.ts
@@ -114,6 +114,39 @@ function ellipticalArcToBezier(cx: number, cy: number, rx: number, ry: number, r
   return [cp1x, cp1y, cp2x, cp2y, x2, y2]
 }
 
+interface ParsedPathCommand {
+  type: string
+  args: number[]
+}
+
+// Path strings come from styles (icon glyphs, overlay shapes) and are immutable
+// between frames, but were re-tokenized with a regex on every draw. Cache the
+// parsed commands keyed by the raw path string so repeated draws reuse them.
+const pathCommandsCache = new Map<string, ParsedPathCommand[]>()
+
+function parsePath(path: string): ParsedPathCommand[] {
+  const cached = pathCommandsCache.get(path)
+  if (cached !== undefined) {
+    return cached
+  }
+  const commands = path.match(/[MLHVCSQTAZ][^MLHVCSQTAZ]*/gi)
+  const parsed: ParsedPathCommand[] = []
+  if (isValid(commands)) {
+    commands.forEach((command) => {
+      parsed.push({
+        type: command[0],
+        args: command
+          .slice(1)
+          .trim()
+          .split(/[\s,]+/)
+          .map(Number)
+      })
+    })
+  }
+  pathCommandsCache.set(path, parsed)
+  return parsed
+}
+
 export function drawPath(ctx: CanvasRenderingContext2D, attrs: PathAttrs | PathAttrs[], styles: Partial<PathStyle>): void {
   let paths: PathAttrs[] = []
   paths = paths.concat(attrs)
@@ -122,8 +155,8 @@ export function drawPath(ctx: CanvasRenderingContext2D, attrs: PathAttrs | PathA
   ctx.strokeStyle = color
   ctx.setLineDash([])
   paths.forEach(({ x, y, path }) => {
-    const commands = path.match(/[MLHVCSQTAZ][^MLHVCSQTAZ]*/gi)
-    if (isValid(commands)) {
+    const commands = parsePath(path)
+    if (commands.length > 0) {
       const offsetX = x
       const offsetY = y
       ctx.beginPath()
@@ -132,12 +165,8 @@ export function drawPath(ctx: CanvasRenderingContext2D, attrs: PathAttrs | PathA
         let currentY = 0
         let startX = 0
         let startY = 0
-        const type = command[0]
-        const args = command
-          .slice(1)
-          .trim()
-          .split(/[\s,]+/)
-          .map(Number)
+        const type = command.type
+        const args = command.args
         switch (type) {
           case 'M':
             currentX = args[0] + offsetX


### PR DESCRIPTION
## Problem

`drawPath` (`src/extension/figure/path.ts`) tokenizes its SVG path string on
every draw:

```ts
const commands = path.match(/[MLHVCSQTAZ][^MLHVCSQTAZ]*/gi)
if (isValid(commands)) {
  commands.forEach((command) => {
    const type = command[0]
    const args = command.slice(1).trim().split(/[\s,]+/).map(Number)
    ...
```

The path strings are static — they come from styles (crosshair feature glyphs in
`CrosshairFeatureView.ts:149-157`, tooltip feature icons in
`IndicatorTooltipView.ts:214-222`) and do not change between frames. But the
crosshair redraws on every mouse move, so the same string is re-tokenized
(regex + `slice` + `split` + `map(Number))` dozens of times per second.

## Fix

Tokenize each path string once and cache the parsed commands in a module-level
`Map<string, ParsedPathCommand[]>` keyed by the raw string. The drawing logic
(the `switch` over command types `M/L/H/V/C/Q/Z` and their relative lowercase
forms) is unchanged — only the source of `type`/`args` changes from inline parsing
to the cached object.

```ts
const pathCommandsCache = new Map<string, ParsedPathCommand[]>()

function parsePath(path: string): ParsedPathCommand[] {
  const cached = pathCommandsCache.get(path)
  if (cached !== undefined) {
    return cached
  }
  ... // tokenize once, store, return
  pathCommandsCache.set(path, parsed)
  return parsed
}
```

In `drawPath`:
```diff
-    const commands = path.match(/[MLHVCSQTAZ][^MLHVCSQTAZ]*/gi)
-    if (isValid(commands)) {
+    const commands = parsePath(path)
+    if (commands.length > 0) {
       ...
-        const type = command[0]
-        const args = command.slice(1).trim().split(/[\s,]+/).map(Number)
+        const type = command.type
+        const args = command.args
```

## Verification

- Output equivalence: parsed `type`/`args` compared against the original inline
  parse on 11 representative path strings (line, cubic, quadratic, arc,
  relative, comma/space separators, decimals, empty, `Z`-only) — **0 differences**.
- The cache returns the same object across calls; `drawPath` only **reads**
  `args[0..6]` and uses local `currentX/Y/startX/Y`, so aliasing is safe.
- Memory growth is bounded: paths are a finite set of style-defined strings
  (typically tens of unique values).
- `pnpm code-lint` — pass (154 files, no fixes)
- `pnpm type-check` — pass
- `pnpm build-umd:prod` — pass

## Notes

- Existing quirks are preserved byte-for-byte, including the per-command reset of
  `currentX/Y/startX/Y` inside `commands.forEach` (which affects relative
  commands — a pre-existing behaviour, not changed here).
- No public API change.