### PR TITLE
perf: cache getBoundingClientRect in EventHandler to avoid layout thrashing

### DIFF
--- a/src/common/EventHandler.ts
+++ b/src/common/EventHandler.ts
@@ -147,6 +147,14 @@ export default class EventHandlerImp {
   private _unsubscribeRootMouseEvents: Nullable<() => void> = null
   private _unsubscribeRootTouchEvents: Nullable<() => void> = null
 
+  // `getBoundingClientRect()` forces a synchronous layout reflow. It is read on
+  // every mouse/touch event via `_makeCompatEvent`, so caching it removes layout
+  // thrashing during fast mousemove/touchmove bursts. The cache is invalidated on
+  // the events that can move or resize the target (scroll, resize, mouseEnter).
+  private _boundingRectCache: Nullable<DOMRect> = null
+  private _unsubscribeScroll: Nullable<() => void> = null
+  private _resizeObserver: Nullable<ResizeObserver> = null
+
   private _startPinchMiddleCoordinate: Nullable<Coordinate> = null
   private _startPinchDistance = 0
   private _pinchPrevented = false
@@ -170,6 +178,7 @@ export default class EventHandlerImp {
     this._options = options
 
     this._init()
+    this._initBoundingRectCache()
   }
 
   destroy(): void {
@@ -213,11 +222,23 @@ export default class EventHandlerImp {
       this._unsubscribeMobileSafariEvents = null
     }
 
+    if (this._unsubscribeScroll !== null) {
+      this._unsubscribeScroll()
+      this._unsubscribeScroll = null
+    }
+
+    this._resizeObserver?.disconnect()
+    this._resizeObserver = null
+    this._boundingRectCache = null
+
     this._clearLongTapTimeout()
     this._resetClickTimeout()
   }
 
   private _mouseEnterHandler(enterEvent: MouseEvent): void {
+    // The cached rect may be stale if the target moved between hover sessions;
+    // refresh at the start of each interaction session.
+    this._invalidateBoundingRect()
     this._unsubscribeMousemove?.()
     this._unsubscribeMouseWheel?.()
     this._unsubscribeContextMenu?.()
@@ -733,6 +754,37 @@ export default class EventHandlerImp {
     this._target.addEventListener('touchmove', () => {}, { passive: false })
   }
 
+  private _initBoundingRectCache(): void {
+    // Page scroll shifts the target's viewport position (`box.left/top`), so the
+    // cache must be invalidated whenever the page is scrolled. Passive listener:
+    // never blocks scrolling, only refreshes the cached rect before the next read.
+    const invalidate = (): void => {
+      this._boundingRectCache = null
+    }
+    window.addEventListener('scroll', invalidate, { passive: true, capture: true })
+    this._unsubscribeScroll = () => {
+      window.removeEventListener('scroll', invalidate, { capture: true })
+    }
+
+    // A ResizeObserver on the target covers size changes (window resize, layout
+    // shifts) without forcing a reflow on every event.
+    if (isValid(ResizeObserver)) {
+      this._resizeObserver = new ResizeObserver(invalidate)
+      this._resizeObserver.observe(this._target)
+    }
+  }
+
+  private _readBoundingRect(): DOMRect {
+    if (this._boundingRectCache === null) {
+      this._boundingRectCache = this._target.getBoundingClientRect()
+    }
+    return this._boundingRectCache
+  }
+
+  private _invalidateBoundingRect(): void {
+    this._boundingRectCache = null
+  }
+
   private _initPinch(): void {
     if (!isValid(this._handler.pinchStartEvent) && !isValid(this._handler.pinchEvent) && !isValid(this._handler.pinchEndEvent)) {
       return
@@ -780,7 +832,7 @@ export default class EventHandlerImp {
   }
 
   private _startPinch(touches: TouchList): void {
-    const box = this._target.getBoundingClientRect()
+    const box = this._readBoundingRect()
     this._startPinchMiddleCoordinate = {
       x: (touches[0].clientX - box.left + (touches[1].clientX - box.left)) / 2,
       y: (touches[0].clientY - box.top + (touches[1].clientY - box.top)) / 2
@@ -859,7 +911,7 @@ export default class EventHandlerImp {
     // TouchEvent has no clientX/Y coordinates:
     // We have to use the last Touch instead
     const eventLike = touch ?? (event as MouseEvent)
-    const box = this._target.getBoundingClientRect()
+    const box = this._readBoundingRect()
     return {
       x: eventLike.clientX - box.left,
       y: eventLike.clientY - box.top,


### PR DESCRIPTION
## Problem

`EventHandler._makeCompatEvent` (called on every `mousemove` / `touchmove` /
`mousedown`) and `_startPinch` call `this._target.getBoundingClientRect()` on
every event. On hi-DPI trackpads that is 120+ events per second, and
`getBoundingClientRect()` forces a **synchronous layout reflow** — the browser
must compute the full layout before returning the rect. This is the classic
layout-thrashing pattern and shows up as jank during pan / zoom / hover.

## Fix

Cache the rect in `_boundingRectCache` and invalidate it on the events that can
move or resize the target:

```ts
private _boundingRectCache: Nullable<DOMRect> = null

private _readBoundingRect(): DOMRect {
  if (this._boundingRectCache === null) {
    this._boundingRectCache = this._target.getBoundingClientRect()
  }
  return this._boundingRectCache
}
```

Invalidation triggers:

1. **scroll** — passive `window` listener with `capture: true`. `scroll` does not
   bubble, but capture-phase listeners on ancestors fire for descendant scroll
   containers, so scrolling any nested container invalidates the cache. `passive: true`
   never blocks scrolling.
2. **resize** — `ResizeObserver` on `_target` (covers window resize and
   layout-caused target resize).
3. **mouseEnter** — refresh at the start of each hover session (a natural point:
   `mousemove` is already re-registered in `_mouseEnterHandler`).

The two `getBoundingClientRect()` call sites (`_makeCompatEvent`, `_startPinch`)
are switched to `_readBoundingRect()`. Listeners and the observer are removed in
`destroy()` (the chain `Chart.destroy` → `Event.destroy` → `EventHandler.destroy`
reaches it), so there is no leak.

`isValid(ResizeObserver)` is used for the observer guard, matching the existing
pattern in `Chart.ts:194`.

## Known limitation

If the target is moved by a CSS transform / margin on an ancestor **without** a
scroll or resize (pure positional translation), the cache is not invalidated and
the crosshair stays offset by the delta until the next `mouseEnter`. This is rare
in stable chart layouts and self-corrects on the next hover session — the same
tradeoff used by `lightweight-charts`. If it matters for a given use case, a
`MutationObserver` on ancestors could be added (at extra overhead).

## Verification

- `_readBoundingRect()` only replaces the read; `_makeCompatEvent` / `_startPinch`
  only read `box.left` / `box.top` (no mutation), so returning the cached object is safe.
- `addEventListener('scroll', invalidate, { passive: true, capture: true })` and
  `removeEventListener('scroll', invalidate, { capture: true })` match on the `capture`
  flag (the only flag `removeEventListener` considers for matching), so the
  listener is removed cleanly in `destroy()`.
- `pnpm code-lint` — pass (154 files, no fixes)
- `pnpm type-check` — pass
- `pnpm build-umd:prod` — pass

## Notes

- `EventHandler` is instantiated once per chart; `_target` is the chart container.
- No public API change. Manual browser verification (crosshair accuracy after
  page scroll and window resize, pan/zoom smoothness on trackpad) is recommended.