### PR TITLE
Fix backward data loading when forward loading is exhausted

### DIFF
--- a/src/Store.ts
+++ b/src/Store.ts
@@ -751,14 +751,10 @@ export default class StoreImp implements Store {
       }
     }
     // More processing and loading, more loading if there are callback methods and no data is being loaded
-    if (from === 0) {
-      if (this._dataLoadMore.forward) {
-        this._processDataLoad('forward')
-      }
-    } else if (to === totalBarCount) {
-      if (this._dataLoadMore.backward) {
-        this._processDataLoad('backward')
-      }
+    if (from === 0 && this._dataLoadMore.forward) {
+      this._processDataLoad('forward')
+    } else if (to === totalBarCount && this._dataLoadMore.backward) {
+      this._processDataLoad('backward')
     }
   }
 


### PR DESCRIPTION
## Description / 变更说明

Fix `Store._adjustVisibleRange()` boundary arbitration when all currently loaded bars fit in the viewport.

When both boundaries are visible with `forward = false` and `backward = true`, the existing outer `from === 0` branch prevents the valid right-boundary backward load from being considered.

This preserves forward-loading priority when it is available while allowing backward loading when the forward direction is exhausted.

## Related Issue / 关联 Issue

Closes #825

## Type of Change / 变更类型

- [x] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Performance improvement / 性能优化
- [ ] Refactor / 代码重构
- [ ] Documentation / 文档更新
- [ ] Build or tooling / 构建或工具链变更
- [ ] Other / 其他

## Testing / 测试说明

The bug was independently reproduced using stock `klinecharts@10.0.2` in Chromium.

The change was then validated in a clean Linux Node 24 environment matching upstream CI closely:

- `pnpm install --frozen-lockfile`
- `pnpm branch-lint`
- `pnpm code-lint`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`

All completed successfully.

The repository does not currently have an automated unit/integration test runner, so this focused fix does not introduce a new test framework solely for this change.

## Checklist / 检查清单

- [x] My changes are focused on a single purpose. / 本次修改聚焦于单一目的。
- [x] I have tested the changes locally. / 我已在本地测试这些修改。
- [x] I have run `pnpm code-lint`. / 我已运行 `pnpm code-lint`。
- [x] I have run `pnpm type-check`. / 我已运行 `pnpm type-check`。
- [x] I have run `pnpm build`. / 我已运行 `pnpm build`。
- [x] I have added or updated documentation where needed. / 我已按需新增或更新文档。
- [ ] I have added or updated tests where needed. / 我已按需新增或更新测试。
- [x] This change does not introduce unrelated modifications. / 本次提交不包含无关修改。