### PR TITLE
feat(overlay): add fixedZLevel to opt out of the hover zLevel raise

### DIFF
--- a/docs/@views/api/references/chart/registerOverlay.md
+++ b/docs/@views/api/references/chart/registerOverlay.md
@@ -7,6 +7,7 @@
     lock?: boolean
     visible?: boolean
     zLevel?: number
+    fixedZLevel?: boolean
     needDefaultPointFigure?: boolean
     needDefaultXAxisFigure?: boolean
     needDefaultYAxisFigure?: boolean

--- a/docs/@views/api/references/instance/createOverlay.md
+++ b/docs/@views/api/references/instance/createOverlay.md
@@ -10,6 +10,7 @@
       lock?: boolean
       visible?: boolean
       zLevel?: number
+      fixedZLevel?: boolean
       needDefaultPointFigure?: boolean
       needDefaultXAxisFigure?: boolean
       needDefaultYAxisFigure?: boolean
@@ -43,6 +44,7 @@
         lock?: boolean
         visible?: boolean
         zLevel?: number
+        fixedZLevel?: boolean
         needDefaultPointFigure?: boolean
         needDefaultXAxisFigure?: boolean
         needDefaultYAxisFigure?: boolean

--- a/docs/@views/api/references/instance/overrideOverlay.md
+++ b/docs/@views/api/references/instance/overrideOverlay.md
@@ -8,6 +8,7 @@
     lock?: boolean
     visible?: boolean
     zLevel?: number
+    fixedZLevel?: boolean
     needDefaultPointFigure?: boolean
     needDefaultXAxisFigure?: boolean
     needDefaultYAxisFigure?: boolean

--- a/docs/api/chart/registerOverlay.md
+++ b/docs/api/chart/registerOverlay.md
@@ -16,6 +16,7 @@ outline: deep
   - `lock` 是否锁定不让拖动。
   - `visible` 是否可见。
   - `zLevel` 绘制层级，值越大，越靠前显示，只作用于覆盖物之间。
+  - `fixedZLevel` 是否固定绘制层级。默认悬浮时会将覆盖物临时提升到最上层，设置为 `true` 后始终保持声明的 `zLevel`。
   - `needDefaultPointFigure` 是否需要默认的点对应的图形。
   - `needDefaultXAxisFigure` 是否需要默认的x轴上的图形。
   - `needDefaultYAxisFigure` 是否需要默认的y轴上的图形。

--- a/docs/api/instance/createOverlay.md
+++ b/docs/api/instance/createOverlay.md
@@ -17,6 +17,7 @@ outline: deep
   - `lock` 是否锁定不让拖动。
   - `visible` 是否可见。
   - `zLevel` 绘制层级，值越大，越靠前显示，只作用于覆盖物之间。
+  - `fixedZLevel` 是否固定绘制层级。默认悬浮时会将覆盖物临时提升到最上层，设置为 `true` 后始终保持声明的 `zLevel`。
   - `needDefaultPointFigure` 是否需要默认的点对应的图形。
   - `needDefaultXAxisFigure` 是否需要默认的x轴上的图形。
   - `needDefaultYAxisFigure` 是否需要默认的y轴上的图形。

--- a/docs/api/instance/overrideOverlay.md
+++ b/docs/api/instance/overrideOverlay.md
@@ -17,6 +17,7 @@ outline: deep
   - `lock` 是否锁定不让拖动。
   - `visible` 是否可见。
   - `zLevel` 绘制层级，值越大，越靠前显示，只作用于覆盖物之间。
+  - `fixedZLevel` 是否固定绘制层级。默认悬浮时会将覆盖物临时提升到最上层，设置为 `true` 后始终保持声明的 `zLevel`。
   - `needDefaultPointFigure` 是否需要默认的点对应的图形。
   - `needDefaultXAxisFigure` 是否需要默认的x轴上的图形。
   - `needDefaultYAxisFigure` 是否需要默认的y轴上的图形。

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1704,17 +1704,21 @@ export default class StoreImp implements Store {
         let ignoreUpdateFlag = false
         let sortFlag = false
         if (overlay !== null) {
-          overlay.override({ zLevel: overlay.getPrevZLevel() })
-          sortFlag = true
+          if (!overlay.fixedZLevel) {
+            overlay.override({ zLevel: overlay.getPrevZLevel() })
+            sortFlag = true
+          }
           if (processOnMouseLeaveEvent(overlay, figure)) {
             ignoreUpdateFlag = true
           }
         }
 
         if (infoOverlay !== null) {
-          infoOverlay.setPrevZLevel(infoOverlay.zLevel)
-          infoOverlay.override({ zLevel: Number.MAX_SAFE_INTEGER })
-          sortFlag = true
+          if (!infoOverlay.fixedZLevel) {
+            infoOverlay.setPrevZLevel(infoOverlay.zLevel)
+            infoOverlay.override({ zLevel: Number.MAX_SAFE_INTEGER })
+            sortFlag = true
+          }
           if (processOnMouseEnterEvent(infoOverlay, info.figure)) {
             ignoreUpdateFlag = true
           }

--- a/src/component/Overlay.ts
+++ b/src/component/Overlay.ts
@@ -148,6 +148,16 @@ export interface Overlay<E = unknown> extends OverlayEventCollection<E> {
   zLevel: number
 
   /**
+   * Whether `zLevel` should stay fixed while the overlay is hovered.
+   *
+   * By default the hovered overlay is temporarily raised above every other
+   * overlay, which makes it impossible to keep a control overlay reliably on
+   * top. Set this to `true` to opt the overlay out of that raise and always
+   * honour its declared `zLevel`.
+   */
+  fixedZLevel: boolean
+
+  /**
    * Whether the default figure corresponding to the point is required
    */
   needDefaultPointFigure: boolean
@@ -241,6 +251,7 @@ export default class OverlayImp<E = unknown> implements Overlay<E> {
   lock = false
   visible = true
   zLevel = 0
+  fixedZLevel = false
   needDefaultPointFigure = false
   needDefaultXAxisFigure = false
   needDefaultYAxisFigure = false


### PR DESCRIPTION
## Description / 变更说明

`Store.setHoverOverlayInfo` raises the hovered overlay to `Number.MAX_SAFE_INTEGER` and only restores it once the pointer moves onto a *different* overlay. While the pointer rests on an overlay, that overlay therefore outranks every other overlay in the pane, and an application cannot keep a control overlay reliably on top — sliding the pointer from a drawing onto an overlapping control leaves the drawing raised, so the control never becomes the hover target and never receives the click. No `zLevel` an application sets can outrank `MAX_SAFE_INTEGER`.

This adds an optional `fixedZLevel` flag on the overlay. When `true`, the overlay keeps its declared `zLevel` while hovered, and is skipped by the matching restore so its level is never clobbered.

It **defaults to `false`**, so the existing raise-on-hover behaviour — which is useful for picking one of several stacked drawings — is unchanged for every current user.

## Related Issue / 关联 Issue

Closes #828

## Type of Change / 变更类型

- [x] Bug fix / Bug 修复
- [x] New feature / 新功能
- [ ] Performance improvement / 性能优化
- [ ] Refactor / 代码重构
- [x] Documentation / 文档更新
- [ ] Build or tooling / 构建或工具链变更
- [ ] Other / 其他

## Testing / 测试说明

Verified in the `debug` playground with two overlapping `horizontalStraightLine` overlays, both declared at `zLevel: 1`, one of them with `fixedZLevel: true`, reading `overlay.zLevel` back while moving the pointer:

| pointer | `plain` (default) | `fixed` (`fixedZLevel: true`) |
| --- | --- | --- |
| elsewhere | `1` | `1` |
| on `plain` | `9007199254740991` | `1` |
| on `fixed` | `1` | **`1`** |
| moved away again | `1` | `1` |

So the default path still raises exactly as before, the opted-out overlay keeps its declared level while hovered, and leaving an overlay does not clobber either level.

Also ran, all passing:

- `pnpm type-check`
- `pnpm code-lint`
- `pnpm build`

## Checklist / 检查清单

- [x] My changes are focused on a single purpose. / 本次修改聚焦于单一目的。
- [x] I have tested the changes locally. / 我已在本地测试这些修改。
- [x] I have run `pnpm code-lint`. / 我已运行 `pnpm code-lint`。
- [x] I have run `pnpm type-check`. / 我已运行 `pnpm type-check`。
- [x] I have run `pnpm build`. / 我已运行 `pnpm build`。
- [x] I have added or updated documentation where needed. / 我已按需新增或更新文档。
- [ ] I have added or updated tests where needed. / 我已按需新增或更新测试。
- [x] This change does not introduce unrelated modifications. / 本次提交不包含无关修改。

<sub>Note on the tests box: the repository currently has no test runner or test files, so there was nothing to extend — hence the manual verification above. Happy to add tests if you'd like to introduce a setup, and equally happy to change the flag name or take a different approach if you'd prefer.</sub>
